### PR TITLE
Update uint8arrays dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "did-jwt": "^5.0.1",
     "fast-json-stable-stringify": "^2.1.0",
     "rpc-utils": "^0.1.3",
-    "uint8arrays": "^1.1.0"
+    "uint8arrays": "^2.1.4"
   }
 }


### PR DESCRIPTION
Updating the version of uint8arrays resolves the following error when using `Ed25519Provider`:

`TypeError: TextDecoder is not a constructor` (because TextDecoder is undefined)